### PR TITLE
doc: add summit meeting minutes

### DIFF
--- a/meetings/2016-12-01.md
+++ b/meetings/2016-12-01.md
@@ -1,0 +1,308 @@
+# VM WG Summit
+
+* Date: 2016-12-01 (Collaborators’ Summit - Austin)
+* Issue: <https://github.com/nodejs/summit/issues/19>
+* Notes: <https://docs.google.com/document/d/1D7-RBkuJiakADIWXOBVNyb6FNSXdoE3XIEXZ1axq97Q>
+
+## Attendees
+
+* Arunesh Chandra (@aruneshchandra)
+* Josh Gavant (@joshgav)
+* Matteo Collina (@mcollina)
+* CJ Ihrig (@cjihrig)
+* Jeremiah Senkpiel (@Fishrock123)
+* Rod Vagg (@rvagg)
+* Taylor Woll (@boingoing)
+* Hitesh Kanwathirtha (@digitalinfinity)
+* James Snell (@jasnell)
+* Stephen Belanger (@qard)
+* Michael Dawson (@mhdawson)
+* Mark Marron (@mrkmarron)
+* Bert Belder (@piscisaureus)
+* Myles Borins (@thealphanerd)
+* JeongHoon Byun (@outsideris)
+* Seth Thompson (@s3ththompson)
+* Charlie Robbins (@indexzero)
+* Dan Shaw (@dshaw)
+
+## Agenda
+
+* Node.js Native API (NAPI)
+* FFI
+* VM compliance spec
+* Next steps
+
+## Node.js Native API (NAPI)
+
+* [Repo](https://github.com/nodejs/abi-stable-node)
+* [EP](https://github.com/nodejs/node-eps/pull/20)
+* [Roadmap](https://github.com/nodejs/abi-stable-node/issues/18)
+
+General roadmap:
+
+1. Stable NAPI for use with native modules. NAN is currently used by many native
+modules; NAPI is addressing weaknesses of NAN abstractions, specifically
+leaking V8 APIs.
+2. Adoption by native modules in the ecosystem.
+3. Adoption by builtin modules in core. These directly use V8 APIs, will
+eventually need to use NAPI.
+
+@rvagg: TJ worked on a stable abstraction for a native ABI, but was too
+difficult because of changes in V8. How confident are we that this ABI will
+actually be stable for a long term, e.g. 12 months?
+
+@mhdawson: Goal has been to prove that current ABI works with 0.10, 0.12, 4.0,
+6.0, and even ChakraCore. Some adjustments were needed, but it wasn’t that
+difficult to hide changes between versions. Proving that this approach works
+
+@rvagg: What about significant future changes in V8? Do we have their buy-in?
+
+@jasnell: Whose responsibility is it to ensure the VM APIs continue to work with
+NAPI? Node’s or the VM owner’s?
+
+@mhdawson: Depends on needs of Node and each VM.
+
+We provide an `Environment*` pointer in each NAPI API, which gives deeper access
+if necessary.
+
+@aruneshchandra: How do we ensure buy-in from VM owners?
+
+@rvagg: If NAPI is accepted downstream VM owners will have to participate.
+
+@s3ththompson: The V8 team haven't yet uncovered any major issues, but we also
+haven't done a full review of the proposal. Does NAPI constrain system design?
+Does it constrain both/either Node or VM owners?
+
+@jasnell: If there were to be a significant change in V8 which would affect NAPI
+would V8 work together with us to address?
+
+@s3ththompson: Hard part is defining an abstraction which provides enough wiggle
+room for innovation.
+
+@rvagg: Would be good to rephrase from “VM Neutrality,” which is somewhat
+controversial, to “ABI Stable Node”, which is what is most important to users.
+
+@mhdawson: Tested some sizeable modules, perf is within reasonable limits. Next
+step is error handling. Also need more feedback from community.
+
+API is C as we don't believe a C++ API can be as ABI-stable. However, we do want
+to add some C++ sugar that would not be part of the ABI-stable API but which
+would be inlined and only call the C API. A good example would be `NAN::New`.
+
+Completed:
+
+* Ported all NAN examples.
+* Ported leveldown and nanomsg.
+
+Next:
+
+* Error handling
+* Perf evaluation.
+
+At that point make available to community and seek further feedback.
+
+@mhdawson: A challenge is that now people can use anything in V8. We will need
+to constrain and support only a subset.
+
+That means this won’t work for 100% of modules, i.e. those which do significant
+work specific to V8.
+
+@jasnell: Are there things in Node which should also be part of this API?
+
+@mhdawson: Some libuv abstractions were already in NAN, learning from some of
+those.
+
+Buffer is another example.
+
+@aruneshchandra: Our plan is to review the native modules in CITGM to validate
+they don't use anything outside of the existing API.
+
+@thealphanerd: There are 4-5 native modules now in CITGM, we could add more.
+
+@indexzero provided a list:
+<https://github.com/nodejs/abi-stable-node/issues/22>
+
+Could we spin up a CITGM instance for testing NAPI in particular?
+
+@thealphanerd: Some of the modules have unusual build steps, they’ll have to be
+investigated. Also CITGM can take a script instead of the default test runner.
+
+What are the next steps on the [EP](https://github.com/nodejs/node-eps/pull/20)?
+
+@mhdawson: Wanted to land as a draft, but still only a PR. We don’t have answers
+to all the questions so haven’t been able to get consensus.
+
+@rvagg: Need to work on landing as a Draft, which is an intended thing. Add
+approval of Node-EP to next week’s CTC agenda.
+
+@aruneshchandra: At what point can we land this in the main repo?
+
+@rvagg: Could land as experimental.
+
+@jasnell: Once we land as experimental will there be a way to back out? See
+v8_inspector as an example.
+
+Discussion:
+* Landing as experimental gives opportunity for more feedback.
+* Would be behind a configure (build-time) flag, not as discoverable as a
+  runtime flag, so less risk of premature dependence.
+
+@aruneshchandra: Should we backport to previous versions to prove usefulness?
+
+@mhdawson: At least 2 LTS's.
+
+And Node-ChakraCore.
+
+First cuts for v8.x to be at end of March, be ready to bring this in behind a
+flag at that time.
+
+@rvagg: Need to ensure CTC is in the loop. Can perhaps achieve that through
+review of Node-EP.
+
+@jasnell: What do we need to achieve to consider NAPI feature-complete? All of
+V8 API?
+
+@aruneshchandra: No, not all of V8, but all that is used by native modules.
+
+@rvagg: But modules may use a lot of those APIs (e.g. garbage collection).
+
+@mhdawson: We’re assuming that’s a low number and we won’t address those in the
+first version.
+
+@mcollina: In order to get ecosystem on board it needs to be extremely
+compelling.
+
+@aruneshchandra: Is the ability to stay with the same module across versions
+sufficiently compelling?
+
+@mcollina: It’s nice, but the problem isn’t that hard to work around. And it
+only happens when a new major version of Node is released. Lack of ecosystem
+buy-in could cripple the effort.
+
+@rvagg: Consider Electron, which often has conflicts with Node.js native
+modules.
+
+@mcollina: That could be a compelling point.
+
+@rvagg: We think mainly about the open source ecosystem, but don’t forget the
+closed users.
+
+@aruneshchandra: People may be misled when testing because their modules based
+on V8 APIs still work.
+
+@mhdawson: We can make sure not to provide the V8 headers in the NAPI includes.
+So you’d get a compile time error if depending on V8 APIs.
+
+@jasnell: Land as experimental behind a configure (build time) flag by v8.x.
+Decide before v8.x LTS whether it can come out from behind the flag.
+
+Then decide at v10.x if it will be fully supported.
+
+**Next steps**:
+
+* CTC to review
+  [Node-EP for abi-stable-node](https://github.com/nodejs/node-eps/pull/20).
+* V8 team to review
+  [NAPI implementation](https://github.com/nodejs/abi-stable-node).
+* NAPI team to test against more native modules in CITGM.
+* Core/CTC to land as experimental behind a build-time flag in 8.0; and to
+* evaluate
+  bringing out from flag when 8.0 goes LTS (Oct 2017).
+
+
+## FFI
+
+@s3ththompson: V8 working on JIT-supported dynamic FFI - “Fast FFI”. Proof of
+concept built which can call synchronous C functions from JS. Working on
+extending to async functions. Next step is to prove in a real-world module.
+
+Once polished V8 will publish in a branch on the V8 repo for evaluation.
+
+It is as performant or even better than native code.
+
+@ofrobots believes this could a solution for the needs of most native addons,
+and requires less overhead.
+
+We could push people to try to avoid C/C++ as much as possible.
+
+@jasnell: How tightly coupled will this be with V8? How hard will it be to port
+or do the same in Chakra and other VMs?
+
+@s3ththompson: Same mechanism could be utilized in other VMs, implementation and
+effects would be different.
+
+@digitalinfinity: This would preclude running Node.js in environments where
+allocating executable memory is not allowed.
+
+Also depends on goals of native module ecosystem. If it’s to use existing C
+libraries, FFI is useful. If it’s to further extend Node.js itself a native API
+is more important.
+
+@rvagg: FFI allows many runtimes to utilize same C library.
+
+@piscisaureus: Has this been tested with significantly complex JS input?
+
+@mrkmarron: Beware of the ease of use of FFI with legacy code, because legacy
+code disrupts analysis and understanding of code.
+
+@aruneshchandra: Do we need to choose one or the other?
+
+@piscisareus: They shouldn’t be mutually exclusive.
+
+@jasnell: Once things land in master, even as experimental, they are difficult
+to revert.
+
+@rvagg: Important to test against current set of modules and how they can be
+covered with both/either Fast-FFI and NAPI.
+
+@mcollina: Also need to consider migration path. Many existing modules in NAN.
+
+@piscisareus: Could we implement NAN over NAPI to ease migration?
+
+@mhdawson: NAN doesn’t cover all the needed abstractions, so some V8 usage is
+still there. So exposing NAPI in terms of NAN won’t fix existing modules.
+
+@piscisareus: Well then expose existing V8 APIs in terms of NAPI too!
+
+@qard: Do we have to? Both NAN and NAPI can coexist.
+
+@piscisareus: NAN will still be needed for those not comfortable with the NAPI C
+API.
+
+@jasnell: Would like to land them both as experimental. But would also like perf
+numbers on both so we can understand and represent them both.
+
+@jasnell: Will V8 have something usable by v8.x (April)?
+
+@s3ththompson: Think so, need to check with Ali (@ofrobots).
+
+@mhdawson: Would be good to have Chakra team review FFI work in V8.
+
+**Next steps**:
+
+* V8 to publish branch with Fast FFI implementation; Node Core and Chakra teams
+  to review.
+
+## VM Compliance Spec
+
+Not ready to tackle this yet. First focus on ABI stable Node.js and FFI. Tackle
+VM compliance later. Will need to consider ES support, diagnostic formats and
+protocols support, etc.
+
+
+## Next steps
+
+* CTC to review
+  [Node-EP for abi-stable-node](https://github.com/nodejs/node-eps/pull/20).
+* V8 team to review
+  [NAPI implementation](https://github.com/nodejs/abi-stable-node).
+* NAPI team to test against more native modules in CITGM.
+* Core/CTC to land as experimental behind a build-time flag in 8.0; and to
+* evaluate
+  bringing out from flag when 8.0 goes LTS (Oct 2017).
+* V8 to publish branch with Fast FFI implementation; Node Core and Chakra teams
+  to review.
+* API WG to hold checkpoint with CTC in late February/early March 2017, demo
+  and discuss NAPI and Fast-FFI.
+* Checkpoint again in mid-July, perhaps in conjunction with a community
+  conference.

--- a/meetings/2017-03-03.md
+++ b/meetings/2017-03-03.md
@@ -1,0 +1,352 @@
+# VM Summit #3 - 2017-03-03
+
+* Recording: https://www.youtube.com/watch?v=ZRVjWhBEwB0
+* Notes:
+  https://docs.google.com/document/d/1mIYQ6YjI2yUS07h5dtkXW-EKgyY2_XYjgVFaZt0Yagk
+
+# Attendees (in person):
+
+* James Snell @jasnell
+* Dan Shaw @dshaw
+* Josh Gavant @joshgav
+* Hitesh Kanwathirtha @digitalinfinity
+* Mark Marron @mrkmarron
+* Arunesh Chandra @aruneshchandra
+* Taylor Woll @boingoing
+* Gaurav Seth @sethgaurav
+* Ed Maurer @EdMaurer
+* Jonathan Carter @lostintangent
+* Jason Ginchereau @jasongin
+* Matthew Loring @matthewloring
+* Ali Ijaz Sheikh @ofrobots
+* Alexis Campailla @orangemocha
+* Gabriel Schulhof @gabrielschulhof
+* Sampson Gao @sampsongao
+* Michael Dawson @mhdawson
+* Matteo Collina @mcollina
+* Colin Ihrig @cjihrig
+* Myles Borins @MylesBorins
+
+# Agenda
+
+* FFI
+* N-API
+* Logistics for landing in core
+* Open discussion on related topics
+
+# FFI
+
+Presentation:
+<https://docs.google.com/presentation/d/1rLBk9Erx1pbqLUBjcq_V2bLsiSxfPWT36dC0yLfFMOE>
+
+@mhdawson: What is needed in core and V8? @ofrobots: Needed APIs have to be
+added to V8. FFI implementation could be encapsulated within a standalone native
+module once those APIs are added.
+
+The V8 capabilities necessary should also be abstracted within NAPI for other
+VMs to implement.
+
+@dshaw: Should we sketch out the equivalent NAPI API together today? @ofrobots:
+Hoped to have more concrete proposal but we don’t. @mhdawson: Should we open a
+public repo with current work and to continue conversation? @ofrobots: Perhaps
+in a couple months, once we have a concrete proposal. @jasnell: Even a list of
+open issues would be helpful.
+
+@ofrobots: As module authors migrate to NAPI, some may be able to avoid C++
+entirely and choose FFI instead.
+
+@mrkmarron: Note that a strong FFI implementation exposes Node.js to the risk of
+users taking more dependencies on legacy native code. That could interfere with
+tools that help with diagnostics and optimizations.
+
+Concern about error handling, for example, when a flow calls back and forth from
+JS to native several times; exceptions might not propagate through multiple
+back-and-forth calls.
+
+@mcollina: Some native modules maintain state on the native side referenceable
+from JS. How would that be addressed with current proposal? nanomsg in fact has
+this issue, how did you handle it? @matthewloring: Did the best we could, would
+be good to think about this more.
+
+@mcollina: Simplest case is a synchronous call passing a couple primitives back
+and forth. That’s useful but doesn’t address more complex modules which for
+example may need access to native objects. @matthewloring: Considered providing
+pointers within JS.
+
+@matthewloring: FFI can provide strongly opinionated flows for common scenarios.
+N-API addresses flows which require different opinions.
+
+@jasnell: Since native APIs for FFI would be included in NAPI, other opinionated
+flows could be developed too.
+
+Timeline? Too early to say, not V8 5.7 or 5.8 so not the first release of Node
+8.
+
+Will it be possible to backport? @ofrobots: Probably not to 6.
+
+Timeline for providing a public drop for collaboration? Part that depends on VM
+implementation needs more maturity before sharing.
+
+Can work on a shared type definition format now and utilize that for early
+implementations.
+
+**Next steps**
+
+* Could begin discussing a shared type definition format now.
+* Matt and Ali to continue work on FFI implementation in private, no timeline
+  for public drop.
+
+---
+
+# N-API
+
+Presentation:
+<https://github.com/nodejs/abi-stable-node/blob/doc/VM%20Summit.pdf>
+
+Error handling: NAPI captures errors and exceptions and module author can handle
+as desired. Also possible to use `napi_throw` functions to throw an exception in
+JS.
+
+C++ API wrapper over C API for convenience, but not planning to include in core.
+
+V8 Isolate APIs little used in modules and don’t plan to include in N-API.
+[deasync](https://www.npmjs.com/package/deasync) uses many of these.
+
+Demo from Arunesh: https://github.com/boingoing/napi_demo. Same native modules -
+canvas, leveldown - used with 6, 8, and Node-ChakraCore.
+
+Canvas perf regression is likely because there’s heavy usage of V8 APIs so much
+more marshaling needed. Also first tried with C++ wrapper. No optimizations yet
+either.
+
+Non-NAPI modules don’t engage NAPI code.
+
+Including in core behind a build flag would make it difficult to experiment with
+since users would have to build Node themselves; so better not to hide behind a
+build flag. But a opt-in runtime flag is needed.
+
+How to handle compatibility as new capabilities are added to VMs and NAPI, e.g.
+at Node’s or TC39’s initiative?
+
+When backporting NAPI modules from e.g. 10 to 8, how to handle newer APIs?
+
+Perhaps add a compiler flag for gyp which allows specifying target NAPI/Node
+version at compile time. Compiler can include appropriate code paths.
+
+Backward compatibility requires NAPI implementation to redirect unavailable
+calls, so there’s a possible perf impact.
+
+@Qard: Maybe we could have versioned additions, similar to Android API levels,
+allowing module writers to specify their﻿ expected minimum version. Could
+do something like `#include "napi/123.h"`. `napi/123.h` would﻿ internally
+include `napi/122.h` and so on, so you just include your minimum version number
+and it's either there or it's not.
+
+For 8.0, include an opt-in runtime flag, show experimental warning when a NAPI
+module is loaded.
+
+Would changing to opt-out be a semver-major change? Would we allow that within
+8.x at all? A: If we keep it experimental we can make bigger changes to it more
+frequently.
+
+Any objections to landing in 8?
+
+* Need to be aware of potential ecosystem impact.
+* Be prepared with any related semver-major changes at beginning of 8 release.
+
+@jasnell: What’s the additional footprint? A: One C file and 3 headers, max
+several hundred K.
+
+@mcollina: Also check impact on heap size and GC behavior.
+
+Get N-API into 8.0 as experimental with a runtime opt-in flag. Ideally include
+in first beta, but may not be ready till second.
+
+Mention FFI effort in N-API announcement, and that they’re complementary
+efforts. No timeline for FFI.
+
+Make sure to land complementary changes in node-gyp and
+[node-pre-gyp](https://github.com/mapbox/node-pre-gyp).
+
+@jasnell will encourage CTC’ers to review.
+
+How can module authors and consumers differentiate between NAPI and NAN/V8 when
+publishing and consuming modules?
+
+Can NAPI be backported to older versions? Do we need to ensure NAPI can be used
+in version 4? In 4.0.0?
+
+Those who stay on old versions often do so because of incompatible native
+modules.
+
+When 8 is released, 4.x will go into maintenance, with only critical or security
+patches. Need to see if people migrate away from 4.
+
+But even if people are using 6, they often aren’t on the latest version of 6. So
+how do we bootstrap use of NAPI on 6?
+
+Possible solution: NAPI as a pre-compiled module usable in 4 too.
+
+Should we only do that and not build it into the runtime? A: No. Would be good
+to build it into later versions of runtime, but still support it in earlier
+versions even if not updated.
+
+Would be good to distribute as an external module compatible with earlier
+runtime versions.
+
+Will there be a performance cost? Maybe, but functional equivalence and greater
+maintainability may be more important to authors.
+
+V8 APIs have changed significantly since 0.10 so porting N-API back is more
+work. @mhdawson: but it’s been done already. @mcollina: focus on 4+ first.
+
+**Next steps**
+
+* Build into 8, take feedback, then consider bootstrap problem and whether to
+  provide as a module like NAN by October (LTS go date).
+* Consider NAPI as a module *if possible* to speed ecosystem adoption.
+
+---
+
+# Related open discussion
+
+## Agenda
+
+* Inspector Protocol and Diagnostics compatibility
+* Definition of compatible Node/VM implementation
+* gyp/gn
+
+## Inspector Protocol and Diagnostics Compatibility
+
+How do we support Inspector in ChakraCore?
+
+@joshgav proposed [#7393](https://github.com/nodejs/node/issues/7393) a
+relatively minor refactor to allow the same stack to interoperate with alternate
+backend implementations. Conversation ongoing between V8 and Chakra on
+implementing something like this.
+
+What about different capabilities surfaced by both platforms, like TTD in
+ChakraCore? @arunesh: Start with supporting base protocol as is in V8, then
+consider additional capabilities.
+
+What’s the relationship of N-API and Inspector?
+* N-API is Node’s contract with native module authors.
+* Inspector is Node’s contract with for diagnostics.
+
+Is Inspector experimental, should support for alternate impls impact that? It’s
+not really experimental anymore in actuality. Also, the implementation changes
+required shouldn’t lead to API changes. So “experimental” tag isn’t that
+relevant.
+
+What about [node-heapdump](https://github.com/bnoordhuis/node-heapdump)?
+@joshgav: Can also be exposed via node-inspect eventually.
+@jasnell: should be compatible with all runtimes.
+@mrkmarron: worked on heap snapshots as part of time-travel debugging. Trying to
+make snapshot format as generic as possible, see
+[comment](https://github.com/nodejs/post-mortem/issues/13#issuecomment-283865030)
+
+llnode? llnode/lldb doesn’t even work on Windows :). Would need an adapter
+between commands and engines.
+
+---
+
+## Definition of supported Node.js VMs
+
+Our approach has been to tackle domains one by one: N-API, Inspector, heap
+format, hosting.
+
+Do SpiderNode and other VMs want to be supported? Yes and plan to snap to final
+decisions, but might not have resources to contribute till then. Similar
+feedback from JSCore.
+
+### Hosting APIs
+
+* N-API currently only represents the runtime API.
+* Would the VMs provide a common hosting API, or would they want Node to
+  implement that?
+
+@ofrobots: More flexibility if VM owners can define their own hosting APIs. Not
+used to adhering to standards since such a shared contract isn’t needed with
+browsers.
+
+@AruneshChandra: Wait to see adoption and reaction to N-API before going into
+hosting APIs.
+
+@mcollina: need to watch ecosystem adoption of alternate VMs, see if people find
+value, and then take next steps.
+
+Suggestion: Should we evolve NAPI to become native to VMs?
+
+Suggestion: Should we implement all builtin modules in NAPI and allow them to be
+loaded outside of node itself, e.g. in d8 and ch?
+
+### ES Support
+
+@jasnell: How to set minimum ES support for engines? Suggestion: Use Test-262 as
+guideline and choose subset of features to implement in Node’s CI.
+
+@williamkapke’s node.green runs Test262 on each engine.
+
+How do we make this straightforward for VM developers? Suggestion: a linter
+which checks for unsupported features.
+
+How do we include minimal VMs which don’t support later ES features? Could they
+still be valid VMs for Node? Could provide multiple profiles.
+
+@dshaw: Currently no VM authors asking for smaller profile, so we shouldn’t pick
+it up till that ask comes.
+
+@jasnell: for now, if it’s green in both Chakra and V8 it’s on Node’s list. If
+other VM authors ask for a more limited subset we can address it then.
+
+We don’t truly need this set till another VM (e.g. ChakraCore) wants to state
+that it’s production ready and not just experimental.
+
+### Platform Support
+
+Can we get Node-ChakraCore on other platforms? ARM should be possible. Could get
+interpreter version running on long tail of platforms earlier. We could have a
+separate list of supported platforms for ChakraCore.
+
+Sentiment is that platform support doesn’t have to be a criteria for a
+“certified” Node VM.
+
+@mylesborins: could we have a Node conformance test? Could include (parts of)
+Test262, WebCompatibilityTest, citgm. Different than current unit tests which
+test functionality as is, not as it should be. Similar issues have come up when
+behavior doesn’t match documentation.
+
+## Build system (gyp/gn)
+
+Native module ecosystem relies on gyp/node-gyp. All native modules have a \*.gyp
+build file. Migrating to a different format would be a burden to authors;
+automated translation would not address more complex uses of gyp.
+
+In the near term CTC will maintain gyp. Fedor has proposed a JS implementation
+of gyp, which Node would still have to maintain.
+
+Probably easier to maintain gyp ourselves rather than try to switch to a
+different build system.
+
+@joshgav: Do we want to maintain our own build system? Or would it be better to
+work with an existing build system like cmake?
+
+@jasnell: Not particularly relevant to NAPI, which could work with existing
+node-gyp. OTOH, introduction of NAPI could provide opportunity to switch system.
+But best not to add something else with NAPI.
+
+Seems like if/when gyp breaks, i.e. as its output format diverges from later
+make, xcode, and VS versions, either we’ll step up and fix it or move on to
+another system.
+
+In conclusion, addressing gyp issue doesn’t seem to be on path for NAPI.
+
+## Next steps
+
+* Land NAPI as experimental behind an opt-in runtime flag for 8.
+* Meet in summer (around NodeSummit) to:
+  * Assess NAPI adoption and progress.
+  * Revisit FFI progress.
+  * Consider supporting old versions with a NAPI module.
+* For further consideration:
+  * What other domains need to be considered for true VM compatibility?


### PR DESCRIPTION
These notes are stored here: https://github.com/nodejs/abi-stable-node/tree/doc/meeting%20notes

But thought they might be better off here for reference. @aruneshchandra @mhdawson thoughts?